### PR TITLE
fix: should check the criteria id in the request first

### DIFF
--- a/src/rest.adapter.ts
+++ b/src/rest.adapter.ts
@@ -38,6 +38,6 @@ export class RestAdapter extends HttpAdapter {
   }
 
   private _getRequestWithId(resource: IResource<any>, request: IHttpRequest) {
-    return new HttpRequest({url: `${this._baseUrl}/${resource.schema.id}/${request.data.id}`}).merge(request);
+    return new HttpRequest({url: `${this._baseUrl}/${resource.schema.id}/${request.criteria["id"] || request.data.id}`}).merge(request);
   }
 }

--- a/tests/adapter.spec.ts
+++ b/tests/adapter.spec.ts
@@ -38,7 +38,7 @@ describe("Adapter", () => {
 
   it(`should find a record`, (done) => {
     adapter.create(resource, deadpoolCreateRequest)
-      .concatMap((response: IHttpResponse) => adapter.findOne(resource, new HttpRequest({data: response.data})))
+      .concatMap((response: IHttpResponse) => adapter.findOne(resource, new HttpRequest({criteria: {id: response.data["id"]}})))
       .subscribe((response: IHttpResponse) => {
         checkDeadpool(response.data);
         done();
@@ -70,8 +70,8 @@ describe("Adapter", () => {
 
   it(`should delete a record`, (done) => {
     adapter.create(resource, deadpoolCreateRequest)
-      .concatMap((response: IHttpResponse) => adapter.destroy(resource, new HttpRequest({data: response.data})))
-      .concatMap((response: IHttpResponse) => adapter.findOne(resource, new HttpRequest({data: response.data})))
+      .concatMap((response: IHttpResponse) => adapter.destroy(resource, new HttpRequest({criteria: {id: response.data["id"]}})))
+      .concatMap((response: IHttpResponse) => adapter.findOne(resource, new HttpRequest({criteria: {id: response.data["id"]}})))
       .subscribe((response: IHttpResponse) => {
         expect(response.data).to.be.undefined;
         done();

--- a/tests/adapter.spec.ts
+++ b/tests/adapter.spec.ts
@@ -39,13 +39,13 @@ describe("Adapter", () => {
   });
 
   it(`should create a record`, () => {
-    checkDeadpool(deadpoolResponse.data);
+    checkHero(deadpool, deadpoolResponse.data);
   });
 
   it(`should find a record when id is within the criteria`, (done) => {
     adapter.findOne(resource, new HttpRequest({criteria: {id: deadpoolResponse.data["id"]}}))
       .subscribe((response: IHttpResponse) => {
-        checkDeadpool(response.data);
+        checkHero(deadpool, response.data);
         done();
       });
   });
@@ -53,7 +53,7 @@ describe("Adapter", () => {
   it(`should find a record when id is within the data`, (done) => {
     adapter.findOne(resource, new HttpRequest({data: deadpoolResponse.data}))
       .subscribe((response: IHttpResponse) => {
-        checkDeadpool(response.data);
+        checkHero(deadpool, response.data);
         done();
       });
   });
@@ -110,10 +110,10 @@ describe("Adapter", () => {
   });
 });
 
-function checkDeadpool(hero) {
-  expect(hero).not.to.be.undefined;
-  expect(hero).to.have.property("id").that.is.not.undefined;
-  expect(hero).to.have.property("name").that.deep.equal(deadpool.name);
-  expect(hero).to.have.property("colors").that.deep.equal(deadpool.colors);
-  expect(hero).to.have.property("powers").that.deep.equal(deadpool.powers);
+function checkHero(originalHero, newHero) {
+  expect(newHero).not.to.be.undefined;
+  expect(newHero).to.have.property("id").that.is.not.undefined;
+  expect(newHero).to.have.property("name").that.deep.equal(originalHero.name);
+  expect(newHero).to.have.property("colors").that.deep.equal(originalHero.colors);
+  expect(newHero).to.have.property("powers").that.deep.equal(originalHero.powers);
 }


### PR DESCRIPTION
When using the **find**, **save** or **destroy** adapter methods, the **id** field should be retrieved from the request **criteria** field first.